### PR TITLE
Removed github url from bower install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A factory to preload images for your Ionic app.
 Install with bower
 
 ```
-bower install ionic-imagecache=https://github.com/jbagaresgaray/ionic-ion-imageCacheFactory.git --save
+bower install ionic-imagecache --save
 ```
 
 ##Usage


### PR DESCRIPTION
bower install ionic-imagecache --save worked perfectly. Hence this pull request so that this can be merged with @andrewmcgivery

This wil close issue https://github.com/andrewmcgivery/ionic-ion-imageCacheFactory/issues/9